### PR TITLE
fix init animation brightness

### DIFF
--- a/SquirtView/SquirtView.ino
+++ b/SquirtView/SquirtView.ino
@@ -128,7 +128,8 @@ void setup(void)
     delay(20);
   }
   delay(200);
-  for (int j = NUM_LEDS; j > -1; j--) 
+  // TODO: Don't like this magic number, maybe have this tied to some brightness variable?
+  for (int j = 16; j > -1; j--) 
   {
     for(int i = 0; i < NUM_LEDS; i++)
     {


### PR DESCRIPTION
Before, this was tied to the number of leds which wasn't intended. I've added a todo because I don't like this just being some magic number it should probably be modified with some kind of brightness setting.